### PR TITLE
Fix the loading content text

### DIFF
--- a/index.html
+++ b/index.html
@@ -125,7 +125,7 @@
       }, 3000);
       <% } %>
 
-      addToLoadScreen("loading index.bundle.js")
+      addToLoadScreen("Loading...")
     </script>
   </body>
 </html>


### PR DESCRIPTION
The loading content is replaced from "loading index.bundle.js" to "loading"