### PR TITLE
102: Allow transition to footnote on first click

### DIFF
--- a/src/components/lazy-html/lazy-html.component.js
+++ b/src/components/lazy-html/lazy-html.component.js
@@ -1,5 +1,6 @@
 import React, { Component } from 'react'
 import { getText } from 'utils/other'
+import history from 'browser-history'
 
 export default class LazyHTML extends Component {
 
@@ -11,6 +12,8 @@ export default class LazyHTML extends Component {
   }
 
   componentDidMount() {
+    this.blockHistory()
+
     this.mounted = true
     if (!this.loading) {
       this.loading = true
@@ -25,6 +28,16 @@ export default class LazyHTML extends Component {
 
   componentWillUnmount() {
     this.mounted = false
+  }
+
+  blockHistory() {
+    history.block(targetLocation => {
+      if (targetLocation.hash) {
+        return false;
+      } else {
+        return true;
+      }
+    });
   }
 
   render() {


### PR DESCRIPTION
**Summary**
This PR fixes the *some* of the issues from the following bug. Clicking a footnote the first time will now bring you to the footnote. Scrolling up and clicking it a second time will reload the page. Then clicking it a third time will properly bring you to the footnotes. There is something weird going on with React Router handling pure markdown/html files in the `LazyHTML` component. We spent 3-4 hours, including about an hour with @DanielJDufour, trying to fully fix this issue to no avail. 

* [ ] #102 


**Test plan (required)**
Zip file (includes the bug that still exists):
[footnotes-functionality.webm.zip](https://github.com/GSA/code-gov-front-end/files/2659982/footnotes-functionality.webm.zip)


**Closing issues**
Doesn't fully close the issue. Issue should be edited to reflect the new state of the fix. 