### PR TITLE
Fixes Footnote Problem

### DIFF
--- a/src/components/lazy-html/lazy-html.component.js
+++ b/src/components/lazy-html/lazy-html.component.js
@@ -23,6 +23,12 @@ export default class LazyHTML extends Component {
     }
   }
 
+  componentDidUpdate() {
+    if (this.props.onUpdate) {
+      this.props.onUpdate()
+    }
+  }
+
   componentWillUnmount() {
     this.mounted = false
   }

--- a/src/utils/url-parsing.js
+++ b/src/utils/url-parsing.js
@@ -1,15 +1,19 @@
 export function getURLSearchParamsAsSimpleObj(search) {
   search = search || window.location.search
-  if (typeof search === 'string') {
+  if (search && typeof search === 'string') {
     return search.substring(1).split('&').reduce((result, part) => {
       try {
-        const [ key, value] = part.split("=");
-        result[key] = decodeURIComponent(value);
+        if (part && part.includes('=')) {
+          const [ key, value] = part.split('=');
+          result[key] = decodeURIComponent(value);
+        }
       } catch (error) {
         console.error(error);
       }
       return result
     }, {});
+  } else {
+    return {}
   }
 }
 


### PR DESCRIPTION


**Summary**
<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] call props' onUpdate method when html is loaded in LazyHTML componen
* [ ] also make sure return empty object from getURLSearchParamsAsSimpleObj when no search in location.  This is was making the source code policy page reload when the user loads a url with a # to footnote

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
User couldn't link to footnotes

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.

<!-- Make sure tests pass on both Travis and Circle CI. -->

**Code formatting**

<!-- See the simple style guide. -->

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #102 