### PR TITLE
Add default placeholder to 'Search Projects' input on search-box

### DIFF
--- a/src/components/search-box/search-box.component.js
+++ b/src/components/search-box/search-box.component.js
@@ -50,7 +50,7 @@ export default class SearchBox extends Component {
           <div className="search-input-and-button-wrapper">
             <input
               onChange={::this.handleChange}
-              placeholder={this.props.placeholder}
+              placeholder={this.props.placeholder || 'Search Projects...'}
               ref={this.textInput}
               type={this.props.inputType || 'search'}
               value={this.state.value}


### PR DESCRIPTION
**Summary**

When we click on the search icon we have this behavior:
![original](https://user-images.githubusercontent.com/5417662/50452542-7c4dd080-0932-11e9-9f3d-acc60fbcebc6.PNG)

So, I think it's interesting add the same (placeholder) on `Search Projects` input on sidebar (search-box), like  we can see bellow:

![new](https://user-images.githubusercontent.com/5417662/50452646-35aca600-0933-11e9-9059-9db52ccbebfd.PNG)

----

After my implementation the result is it:
![newnew](https://user-images.githubusercontent.com/5417662/50452752-f468c600-0933-11e9-8c3e-31fba881e7ea.PNG)

I think the current behavior is not intuitive because users don't know what they can search or type on this input...