### PR TITLE
Add newsletter link to home

### DIFF
--- a/config/site/site.json
+++ b/config/site/site.json
@@ -123,7 +123,8 @@
         "search_description_text_mobile": "Search projects",
         "search_placeholder_text": "e.g. JavaScript, NASA, web standards",
         "browse_by_text": "Browse by Agency",
-        "issue_url": "https://github.com/GSA/code-gov-front-end/issues"
+        "issue_url": "https://github.com/GSA/code-gov-front-end/issues",
+        "newsletter_url": "https://public.govdelivery.com/accounts/USGSATTS/subscriber/new?topic_id=USGSATTS_5"
       },
       "mission": "Code.gov leverages the power of code sharing and collaboration to help the US Government cut down on duplicative software development and save millions of taxpayer dollars for the American people.",
       "about": [{

--- a/src/components/home-banner/home-banner.component.js
+++ b/src/components/home-banner/home-banner.component.js
@@ -86,7 +86,8 @@ export default class HomeBanner extends React.Component {
           <div className="banner-subsection">
             <div className="banner-subsection-subtitle" id="issue-banner-subsection-subtitle">
               <img className="chat" src={PUBLIC_PATH + 'assets/img/icons/chat_bubble.png'}/>
-              <span>Have questions or feedback? Open an issue on our <a className="link" href={this.props.issueUrl} id="issue-link" target="_blank">open source repository</a>.</span>
+              <span>Have questions or feedback? Open an issue on our <a className="home-link link" href={this.props.issueUrl} target="_blank">open source repository</a>.</span>
+              <div>Want to receive our monthly newsletter? <a className="home-link link" href={this.props.newsletterUrl} target="_blank">Sign up here</a>.</div>
             </div>
           </div>
         </div>

--- a/src/components/home-banner/home-banner.component.js
+++ b/src/components/home-banner/home-banner.component.js
@@ -85,6 +85,7 @@ export default class HomeBanner extends React.Component {
           <br/>
           <div className="banner-subsection">
             <div className="banner-subsection-subtitle" id="issue-banner-subsection-subtitle">
+            <h2 className="banner-subsection-title">Connect with Us</h2>
               <img className="chat" src={PUBLIC_PATH + 'assets/img/icons/chat_bubble.png'}/>
               <span>Have questions or feedback? Open an issue on our <a className="home-link link" href={this.props.issueUrl} target="_blank">open source repository</a>.</span>
               <div>Want to receive our monthly newsletter? <a className="home-link link" href={this.props.newsletterUrl} target="_blank">Sign up here</a>.</div>

--- a/src/components/home-banner/home-banner.container.js
+++ b/src/components/home-banner/home-banner.container.js
@@ -15,6 +15,7 @@ const mapStateToProps = ({ agencies }) => {
     helpWantedDescription: getConfigValue('content.home.banner.help_wanted.description'),
     helpWantedButton: getConfigValue('content.home.banner.help_wanted.button'),
     issueUrl: getConfigValue('content.home.banner.issue_url'),
+    newsletterUrl: getConfigValue('content.home.banner.newsletter_url'),
     browseByText: getConfigValue('content.home.banner.browse_by_text')
   }
 }

--- a/styles/home-banner.scss
+++ b/styles/home-banner.scss
@@ -95,4 +95,11 @@ section#banner-home {
     height: 30px;
     vertical-align: middle;
   }
+
+  .home-link {
+    color: $brand-teal;
+    &:hover {
+      text-decoration: none;
+    }
+  }
 }

--- a/styles/home.scss
+++ b/styles/home.scss
@@ -333,10 +333,3 @@
   max-width: 100%;
   width: 100%;
 }
-
-#issue-link {
-  color: $brand-teal;
-  &:hover {
-    text-decoration: none;
-  }
-}


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->
🔎 [PREVIEW](https://staging.code.gov/)

This PR fixes/implements the following **bugs/features**

* [ ] Add a signup link to the newsletter on the home page

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

BEFORE:
<img width="1375" alt="Screen Shot 2019-03-13 at 5 39 23 PM" src="https://user-images.githubusercontent.com/2197515/54316414-0a8f3580-45b7-11e9-8543-f844e9a0879f.png">

AFTER:
<img width="1212" alt="Screen Shot 2019-03-14 at 11 19 15 AM" src="https://user-images.githubusercontent.com/2197515/54368731-0dd40100-464b-11e9-9016-5205b20a0edc.png">

