### PR TITLE
Fix menu bug

### DIFF
--- a/src/components/menu/menu.component.js
+++ b/src/components/menu/menu.component.js
@@ -42,10 +42,9 @@ export default class Menu extends Component {
   }
 
   onClickMenuOption(selected, event) {
-
     const menu = this.state.menu.map(menuOption => {
-      if (menuOption !== selected) {
-        menuOption.expanded = false
+      if (menuOption.name == selected.name) {
+        menuOption.expanded = true
       }
       return menuOption
     })
@@ -55,7 +54,6 @@ export default class Menu extends Component {
     const height = selected.expanded ? 74 + 40 * selected.links.length : 'auto'
 
     const expanded = this.state.menu.some(menuOption => menuOption.expanded)
-
     this.setState({ expanded, menu, height })
   }
 


### PR DESCRIPTION
Fixes an issue where background color for the main nav was not changing when an item with a dropdown was selected. On load, the main nav background is transparent to show the banner image behind it. When a menu item is selected, the background color should change to black so that the subnav menu items are readable.

BEFORE:
<img width="316" alt="Screen Shot 2019-05-02 at 6 37 43 PM" src="https://user-images.githubusercontent.com/2197515/57111326-b62c4a80-6d09-11e9-9142-2f3a8924d9ff.png">

AFTER:
<img width="300" alt="Screen Shot 2019-05-02 at 6 38 02 PM" src="https://user-images.githubusercontent.com/2197515/57111336-bfb5b280-6d09-11e9-8e9d-cdf2dbef1822.png">
