### PR TITLE
Update footer link to repo

### DIFF
--- a/config/site/examples/your-city.json
+++ b/config/site/examples/your-city.json
@@ -82,7 +82,7 @@
         },
         {
           "name": "Visit Project Page",
-          "url": "https://github.com/GSA/code-gov-web"
+          "url": "https://github.com/GSA/code-gov"
         }
       ],
       "logos": [

--- a/config/site/site.json
+++ b/config/site/site.json
@@ -219,7 +219,7 @@
         },
         {
           "name": "Visit Project Page",
-          "url": "https://github.com/GSA/code-gov-front-end"
+          "url": "https://github.com/GSA/code-gov"
         }
       ],
       "logos": [{

--- a/tests/unit/components/footer/__snapshots__/footer.container.test.js.snap
+++ b/tests/unit/components/footer/__snapshots__/footer.container.test.js.snap
@@ -14,7 +14,7 @@ Object {
     },
     Object {
       "name": "Visit Project Page",
-      "url": "https://github.com/GSA/code-gov-front-end",
+      "url": "https://github.com/GSA/code-gov",
     },
   ],
   "logos": Array [


### PR DESCRIPTION
Point the 'View Project Page' link to https://github.com/GSA/code-gov instead of code-gov-front-end.