### PR TITLE
Change repo link to code-gov

### DIFF
--- a/config/site/site.json
+++ b/config/site/site.json
@@ -60,7 +60,7 @@
         {
           "name": "SOCIAL",
           "links": [
-            { "name": "code.gov Repo", "url": "http://github.com/GSA/code-gov-front-end" },
+            { "name": "code.gov Repo", "url": "http://github.com/GSA/code-gov" },
             { "name": "Blog", "url": "https://medium.com/codedotgov" },
             { "name": "LinkedIn", "url": "https://www.linkedin.com/company/code-gov" },
             { "name": "Twitter", "url": "https://twitter.com/codedotgov" },
@@ -101,7 +101,7 @@
         {
           "name": "Social",
           "links": [
-            { "name": "code.gov Repo", "url": "http://github.com/GSA/code-gov-front-end" },
+            { "name": "code.gov Repo", "url": "http://github.com/GSA/code-gov" },
             { "name": "Blog", "url": "https://medium.com/codedotgov" },
             { "name": "LinkedIn", "url": "https://www.linkedin.com/company/code-gov" },
             { "name": "Twitter", "url": "https://twitter.com/codedotgov" },

--- a/tests/unit/components/menu/__snapshots__/menu.container.test.js.snap
+++ b/tests/unit/components/menu/__snapshots__/menu.container.test.js.snap
@@ -73,7 +73,7 @@ Object {
       "links": Array [
         Object {
           "name": "code.gov Repo",
-          "url": "http://github.com/GSA/code-gov-front-end",
+          "url": "http://github.com/GSA/code-gov",
         },
         Object {
           "name": "Blog",

--- a/tests/unit/components/mobile-menu/__snapshots__/mobile-menu.container.test.js.snap
+++ b/tests/unit/components/mobile-menu/__snapshots__/mobile-menu.container.test.js.snap
@@ -70,7 +70,7 @@ Object {
       "links": Array [
         Object {
           "name": "code.gov Repo",
-          "url": "http://github.com/GSA/code-gov-front-end",
+          "url": "http://github.com/GSA/code-gov",
         },
         Object {
           "name": "Blog",


### PR DESCRIPTION
In the main navigation, change Social -> code.gov Repo link.

Before:
Link pointed to code-gov-front-end repo

After:
Link points to code-gov repo

<img width="192" alt="Screen Shot 2019-05-06 at 8 57 25 AM" src="https://user-images.githubusercontent.com/2197515/57226417-fe36c000-6fdc-11e9-9d94-cbc5965aa9ea.png">