### PR TITLE
Make eslint aware of Jest functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -8,6 +8,9 @@
     "document": true,
     "window": true
   },
+  "env": {
+    "jest": true
+  },
   "parser": "babel-eslint",
   "plugins": [
     "prettier"


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Tests were showing linter warnings because eslint didn't think Jest functions like `describe`, `it`, `beforeEach` and `expect` were defined anywhere.

**Test plan (required)**

This change did not affect app code so it did not require any tests to be created or updated.

I added an `env` object to the `.eslintrc` settings object and named Jest as one of the linting environments.

```
  "env": {
    "jest": true
  },
```

before change
![kill-jest-linting-errors-before](https://user-images.githubusercontent.com/5049650/57397079-7ba33180-7191-11e9-8211-9a6f763b1bd0.png)

after change
![kill-jest-linting-errors-after](https://user-images.githubusercontent.com/5049650/57397087-8067e580-7191-11e9-8223-34ffa6314312.png)

<!-- Make sure tests pass on both Travis and Circle CI. -->