### PR TITLE
Bump sitemap version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1471,12 +1471,20 @@
       "integrity": "sha512-AMFnTN4eIn+AOd9qEzbd2dB2QUgSi8G90pdt81eHsUz96LIg8uHi2ApYXZ/eY6JF5jEyNCoWTPEVHY45iHw7rA=="
     },
     "@code.gov/site-map-generator": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.2.tgz",
-      "integrity": "sha512-KacHIZtyPgZetI3bFBrp6OBnfwIPwNeNCQZEpMLOfmjmnZgx3inLrJGb9xHOfXx1j+xNlrJ34k1CRz8hpy646Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.3.tgz",
+      "integrity": "sha512-8VFFO+IehefrWKluIYENWDKdtEd1kQSXZBvXr2RVa/jyr4hGtY/7CT9Kb56fYmxzn4Qb39mPWbKVB0Zv6JMCIA==",
       "requires": {
         "@code.gov/api-client": "^0.3.3",
+        "dotenv": "^8.0.0",
         "xmlbuilder": "^10.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
+          "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+        }
       }
     },
     "@jest/console": {
@@ -2491,7 +2499,7 @@
     },
     "axios": {
       "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
       "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
       "requires": {
         "follow-redirects": "^1.3.0",
@@ -4150,7 +4158,7 @@
         },
         "regjsparser": {
           "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
+          "resolved": "http://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
           "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
           "dev": true,
           "requires": {
@@ -4667,7 +4675,7 @@
     },
     "duplexer": {
       "version": "0.1.1",
-      "resolved": "http://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.1.tgz",
       "integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E="
     },
     "duplexer3": {
@@ -5891,7 +5899,7 @@
     },
     "favicons-webpack-plugin": {
       "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/favicons-webpack-plugin/-/favicons-webpack-plugin-0.0.9.tgz",
+      "resolved": "http://registry.npmjs.org/favicons-webpack-plugin/-/favicons-webpack-plugin-0.0.9.tgz",
       "integrity": "sha1-32PoDFVrgE5JJeyOBb7jY5FXPck=",
       "dev": true,
       "requires": {
@@ -7514,7 +7522,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         }
@@ -12802,7 +12810,7 @@
         },
         "string_decoder": {
           "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
           "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
           "dev": true
         },
@@ -14414,7 +14422,7 @@
     },
     "string_decoder": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "requires": {
         "safe-buffer": "~5.1.0"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@code.gov/fscp-react-component": "0.3.4",
     "@code.gov/json-schema-validator-web-component": "^0.2.0",
     "@code.gov/json-schema-web-component": "0.4.0",
-    "@code.gov/site-map-generator": "^1.0.2",
+    "@code.gov/site-map-generator": "^1.0.3",
     "@webcomponents/custom-elements": "^1.2.4",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.10.0",


### PR DESCRIPTION
Update sitemap version to [v1.0.3](https://github.com/GSA/code-gov-site-map-generator/releases/tag/v1.0.3)