### PR TITLE
Fix sitemap copy to prod issue

### DIFF
--- a/config/webpack/webpack.shared.js
+++ b/config/webpack/webpack.shared.js
@@ -114,7 +114,7 @@ const patterns = [
   }
 ]
 
-if (process.env.CODE_GOV_BRANCH === 'federalist-prod') {
+if (process.env.OUTPUT_RELATIVE_PATH.includes('federalist-prod')) {
   // only include sitemap if building for production on code.gov
   patterns.push({
     from: 'node_modules/@code.gov/site-map-generator/sitemap.xml',

--- a/config/webpack/webpack.shared.js
+++ b/config/webpack/webpack.shared.js
@@ -114,7 +114,7 @@ const patterns = [
   }
 ]
 
-if (process.env.OUTPUT_RELATIVE_PATH.includes('federalist-prod')) {
+if (process.env.OUTPUT_RELATIVE_PATH && process.env.OUTPUT_RELATIVE_PATH.includes('federalist-prod')) {
   // only include sitemap if building for production on code.gov
   patterns.push({
     from: 'node_modules/@code.gov/site-map-generator/sitemap.xml',

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "node deploy.js",
     "deploy-to-gh-pages": "PUBLIC_PATH='/code-gov-front-end/' OUTPUT_RELATIVE_PATH='/dist/gh-pages' npm run build && CODE_GOV_RELATIVE_DIR='/dist/gh-pages' CODE_GOV_BRANCH='gh-pages' npm run deploy",
     "deploy-to-staging": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-stag' npm run build && CODE_GOV_RELATIVE_DIR='/dist/federalist-stag' CODE_GOV_BRANCH='federalist-stag' npm run deploy",
-    "deploy-to-production": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-prod' npm run build && CODE_GOV_BRANCH='federalist-prod' CODE_GOV_RELATIVE_DIR='/dist/federalist-prod' npm run deploy",
+    "deploy-to-production": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-prod' npm run build && CODE_GOV_RELATIVE_DIR='/dist/federalist-prod' CODE_GOV_BRANCH='federalist-prod' npm run deploy",
     "install-about-plugin": "cp -fr ./node_modules/@code.gov/about-page/pages/html/* ./assets/plugins/about-page/.",
     "install-fscp-plugin": "cp ./node_modules/@code.gov/fscp-react-component/pages/html/* ./assets/plugins/fscp-react-component/.",
     "licenses": "license-checker --json --relativeLicensePath --out dependency_licenses.json",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "node deploy.js",
     "deploy-to-gh-pages": "PUBLIC_PATH='/code-gov-front-end/' OUTPUT_RELATIVE_PATH='/dist/gh-pages' npm run build && CODE_GOV_RELATIVE_DIR='/dist/gh-pages' CODE_GOV_BRANCH='gh-pages' npm run deploy",
     "deploy-to-staging": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-stag' npm run build && CODE_GOV_RELATIVE_DIR='/dist/federalist-stag' CODE_GOV_BRANCH='federalist-stag' npm run deploy",
-    "deploy-to-production": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-prod' npm run build && CODE_GOV_RELATIVE_DIR='/dist/federalist-prod' CODE_GOV_BRANCH='federalist-prod' npm run deploy",
+    "deploy-to-production": "PUBLIC_PATH='/' OUTPUT_RELATIVE_PATH='/dist/federalist-prod' npm run build && CODE_GOV_BRANCH='federalist-prod' CODE_GOV_RELATIVE_DIR='/dist/federalist-prod' npm run deploy",
     "install-about-plugin": "cp -fr ./node_modules/@code.gov/about-page/pages/html/* ./assets/plugins/about-page/.",
     "install-fscp-plugin": "cp ./node_modules/@code.gov/fscp-react-component/pages/html/* ./assets/plugins/fscp-react-component/.",
     "licenses": "license-checker --json --relativeLicensePath --out dependency_licenses.json",


### PR DESCRIPTION
## Summary
This PR fixes/implements the following **bugs/features**
- 🐛 correctly copies the sitemap.xml file to `/dist/federalist-prod` on prod deploys

## Motivation
- The sitemap was not being [copied to production](https://trello.com/c/G1Jj10PX/1453-fix-sitemap-issue-on-front-end).

## Test plan (required)
- after making this change, when I ran `npm run deploy-to-production` with the `ghpages` parts of `deploy.js` commented out, the sitemap was correctly copied to `/dist/federalist-prod` 