### PR TITLE
Fix linting issue 2019.06.04

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,5 +1,5 @@
 # code.gov plugins
-/src/components/plugins
+src/components/plugins
 
 # Ignore dist and docs files
 dist/*

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Code.gov — America’s Home for Open Source Projects from the Federal Governmen",
   "main": "index.js",
   "scripts": {
-    "lint": "eslint src/**/* --ext .js,.jsx --fix",
+    "lint": "eslint 'src/**/*' --ext .js,.jsx --fix",
     "prettier": "pretty-quick --staged",
     "analyze": "webpack --config ./config/webpack/webpack.analyze.js",
     "build": "webpack --config ./config/webpack/webpack.prod.js",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "lint-staged": {
     "*.{js,jsx}": [
       "pretty-quick --staged",
-      "eslint src/**/* --ext .js,.jsx --fix",
+      "eslint 'src/**/*' --ext .js,.jsx --fix",
       "git add"
     ]
   },


### PR DESCRIPTION
## Summary
🐛 The `npm run lint` command was triggering errors. This PR edits the offending scripts so that these errors no longer occur.

## Test plan (required)
Pull down this branch locally and run the `npm run lint` command. Notice that the project files are now being linted.