### PR TITLE
Add Google Tag Manager to <head>

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,6 +21,13 @@
       }
     </script>
 
+    <!-- We use Google Tag Manager to participate in the US Government's Digital Analytics Program (DAP). You can see the data for code.gov and other federal websites at analytics.usa.gov -->
+    <script>
+      <% if (ENABLE_GOOGLE_ANALYTICS === true) { %>
+      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5CKH6WC');
+      <% } %>
+    </script>
+    <!-- End Google Tag Manager -->
 
     <meta charset="utf-8">
     <meta http-equiv="x-ua-compatible" content="ie=edge">
@@ -87,7 +94,6 @@
     </div>
     <script src="<%= PUBLIC_PATH %>webcomponents/code-gov-web-components.js" defer></script>
     <script>
-
       function loadScript(url) {
         var script = document.createElement('script');
         script.src = url;
@@ -112,25 +118,6 @@
         console.warn("This browser doesn't support CustomEvent, which is used by code-gov-style, so we'll load a polyfill");
         loadScript('<%= PUBLIC_PATH %>polyfills/custom-event.js');
       }
-
-      function injectScript(innerHTML, type, src, id) {
-        var script = document.createElement('script');
-        script.innerHTML = innerHTML;
-        script.type = type;
-        script.src = src;
-        script.id = id;
-        document.head.appendChild(script);
-      }
-
-      <% if (ENABLE_GOOGLE_ANALYTICS === true) { %>
-      setTimeout(function() {
-        // We use Google Tag Manager to track events on code.gov
-        injectScript("(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start': new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0], j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5CKH6WC');", "", "", "");
-        
-        // We participate in the US government's analytics program (DAP). You can see the data for code.gov and other federal websites at analytics.usa.gov.
-        injectScript("", "text/javascript", "https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=GSA", "_fed_an_ua_tag");
-      }, 3000);
-      <% } %>
     </script>
   </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,7 @@
       }
     </script>
 
-    <!-- We use Google Tag Manager to participate in the US Government's Digital Analytics Program (DAP). You can see the data for code.gov and other federal websites at analytics.usa.gov -->
+    <!-- We use Google Tag Manager to participate in the Federal Government's Digital Analytics Program (DAP). You can see the data for code.gov and other federal websites at analytics.usa.gov -->
     <script>
       <% if (ENABLE_GOOGLE_ANALYTICS === true) { %>
       (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);})(window,document,'script','dataLayer','GTM-5CKH6WC');


### PR DESCRIPTION
**Summary**

Add Google Tag Manager script directly to head of index.html instead of injecting it so that it is compatible with the Google Tag Assistant Chrome Extension

**Motivation**

This refactor ensures that our team and contributors can use the Google Tag Assistant Chrome Extension to test our integration with the [Digital Analytics Program (DAP)](https://digital.gov/dap/). The old method of integrating Google Tag Manager via injection was meant to prevent bots from influencing our analytics data (by delaying analytics tracking for 3 seconds) but this prevented the Google Tag Assistant from working

**Test plan (required)**

Run npm run test. All tests pass (except for one which is also failing on master)