### PR TITLE
Address HTML Errors

### DIFF
--- a/config/webpack/webpack.shared.js
+++ b/config/webpack/webpack.shared.js
@@ -216,7 +216,12 @@ module.exports = {
     ]),
     new CleanWebpackPlugin([OUTPUT_PATH], { root: rootDir }),
     new CopyWebpackPlugin(patterns),
-    new FaviconsWebpackPlugin('./assets/img/favicon.png'),
+    new FaviconsWebpackPlugin({
+      logo: './assets/img/favicon.png',
+      icons: {
+        appleStartup: false
+      }
+    }),
     new HtmlWebpackPlugin({
       hash: true,
       template: 'index.html',
@@ -224,6 +229,9 @@ module.exports = {
         PUBLIC_PATH
       },
       title: 'code.gov',
+      minify: {
+        removeScriptTypeAttributes: true
+      }
     })
   ],
   watchOptions: {


### PR DESCRIPTION
## Summary
This PR fixes/implements the following **bugs/features**:
* [ ] change webpack settings to remove unnecessary type attribute on the bundle index.html script tags
* [ ] change webpack settings to not create `apple-touch-startup-image` link tags  in the bundle index.html file

## Motivation
- https://trello.com/c/4twJsk8B/1321-10-fix-html-issues

## Test plan (required)
Test this PR by pulling the branch down and running the `npm run build` command on your local machine. You'll notice that the `index.bundle.js` script tag has no `type` attribute and that there are no more links with a `rel`value of "apple-touch-startup-image".