### PR TITLE
Add .DS_Store to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,6 @@ typings/
 
 # code.gov plugins
 /src/components/plugins
+
+# .DS_Store
+.DS_Store


### PR DESCRIPTION
**Summary**

Add the .DS_Store file to the .gitignore so that it doesn't get unintentionally committed to the repo (which is unnecessary and can cause merge conflicts)