### PR TITLE
refactor: Search form input + button updated to keep correct width

### DIFF
--- a/styles/search.scss
+++ b/styles/search.scss
@@ -35,13 +35,22 @@
       text-align: center;
       /* 100% minus width of the button */
       width: calc(100% - 40px);
+
+      display: inline-block;
+      padding: 0;
+      margin: 0;
+      border: 0;
     }
 
     button.go {
-      border: 0px;
+      border: 0;
       height: 40px;
-      margin-right: 0;
-      position: absolute;
+      float: none;
+      display: inline-block;
+      vertical-align: top;
+      margin: 0 !important;
+      padding: 0 !important;
+      font-size: 1.2rem;
     }
 
     .autocomplete {
@@ -55,11 +64,28 @@
 }
 
 .mobile-menu {
-  .search-input-and-button-wrapper {
+  .search-input-and-button-wrapper,
+  .search-form {
     text-align: center;
 
+    input {
+      display: inline-block;
+      padding: 0;
+      margin: 0;
+      border: 0;
+      font-size: 1.4rem;
+      text-align: center;
+    }
+
     button.go {
-      position: static;
+      height: 40px;
+      float: none;
+      display: inline-block;
+      vertical-align: top;
+      margin: 0 !important;
+      padding: 0 !important;
+      border: 0 !important;
+      font-size: 1.2rem;
     }
   }
 }


### PR DESCRIPTION
**Summary**
  - Currently, the "search form" is available on three different
   pages:
    - Home
    - Browse Projects
    - Navbar (mobile)

  - Before this update, both the input and the button next to it
   inherited incorrect and inconsistent styles by importing
   a style file.

See also: #251

----

### Print Screens

**Smartphone iPhone 5/SE**
- Home
![iphone-5-home](https://user-images.githubusercontent.com/5417662/59957866-b5a46a80-9495-11e9-9fc1-fff0c5c2380d.png)

- Browse Projects
![iphone-5-search-projects](https://user-images.githubusercontent.com/5417662/59957871-d8368380-9495-11e9-84e6-90123f77a3a7.png)

- Navbar
![iphone-5-navbar](https://user-images.githubusercontent.com/5417662/59957875-e2588200-9495-11e9-9265-5e61be279455.png)

**Tablets**
- Home
![tablet-home](https://user-images.githubusercontent.com/5417662/59957881-f0a69e00-9495-11e9-8086-8e404e64fa43.png)

- Browse Projects
![tablet-search-projects](https://user-images.githubusercontent.com/5417662/59957886-f8664280-9495-11e9-84ea-41e9c2f3b494.png)

- Navbar
![tablet-navbar](https://user-images.githubusercontent.com/5417662/59957889-fc926000-9495-11e9-9d40-b55aa8ebf2f7.png)

**Desktop**
- Home
![desktop-home](https://user-images.githubusercontent.com/5417662/59957920-63177e00-9496-11e9-9cd7-546a8e2aa63b.png)

- Browse Projects
![desktop-search-projects](https://user-images.githubusercontent.com/5417662/59957922-67439b80-9496-11e9-88f3-27c4f034f8b3.png)
