### PR TITLE
refactor: Transform a footer in a pure component

### DIFF
--- a/src/components/footer/footer.component.js
+++ b/src/components/footer/footer.component.js
@@ -1,9 +1,9 @@
 /* global PUBLIC_PATH */
-import React, { Component } from 'react'
-import CustomLink from 'components/custom-link'
 import { map, startsWith } from '@code.gov/cautious'
+import CustomLink from 'components/custom-link'
+import React, { PureComponent } from 'react'
 
-export default class Footer extends Component {
+export default class Footer extends PureComponent {
   render() {
     return (
       <footer className={this.props.color} role="contentinfo">


### PR DESCRIPTION
**Summary**

  - React components can be defined by subclassing
   `React.Component` or `React.PureComponent`. In the
   React Components' docs we can read this paragraph:

   > If your React component’s render() function renders the
   same result given the same props and state, you can use
   `React.PureComponent` for a performance boost in some cases.

  - [Pure Components - React Docs](https://reactjs.org/docs/react-api.html#reactpurecomponent)

See also: #251 