### PR TITLE
refactor: Transform zero{px} to zero absolute

### DIFF
--- a/styles/project-page.scss
+++ b/styles/project-page.scss
@@ -13,15 +13,10 @@
     }
   }
   button {
-    margin-top: 1.5rem;
-    margin-right: 5px;
-    margin-bottom: 0px;
-    margin-left: 0px;
+    margin: 1.5rem 5px 0 0;
   }
 
-
   .repo-container {
-
     code {
       background-color: $brand-blue-gray;
       border-radius: 3px;
@@ -43,21 +38,18 @@
   }
 
   .repo-actions {
-
     li {
       display: inline-block;
     }
   }
 
   .repo-features {
-    margin-top: 1.5rem;
-    margin-right: 0px;
-    margin-bottom: 2rem;
-    margin-left: 0px;
+    margin: 1.5rem 0 2rem 0;
     width: 100%;
     border-bottom: 1px lightgray solid;
 
-    li,span.li {
+    li,
+    span.li {
       display: inline;
       color: $brand-blue-dark;
       margin-right: 2em;
@@ -68,7 +60,6 @@
   }
 
   .repo-header-container {
-
     h1 {
       margin: 0 0 0.25em;
     }
@@ -97,15 +88,11 @@
 
   .icon {
     color: $brand-blue;
-    margin-top: 0pxm;
-    margin-right: 0px;
-    margin-bottom: .7rem;
-    margin-left: 0px;
+    margin: 0 0 0.7rem 0;
     padding: 0;
     padding-right: 1.1em;
     padding-bottom: 1.1em;
   }
-
 
   .language.last {
     .comma {


### PR DESCRIPTION
**Summary**  
  - Zero{px, pt, em, rem, whatever valid unit of measurement}
   vs Zero absolute are equivalent;
  - They are identical, I have suggesting
   `[width, height, padding, margin, ...]: 0`, because it's
   shorter and more readable.
     - Especially when you have, for example:
   `padding: 0px 0px 9px 8px`
   vs
   `padding: 0 0 9px 8px`

  - [See the specs or read the abstract below](https://www.w3.org/TR/CSS21/syndata.html#values)

   > The format of a length value (denoted by <length> in this
   specification) is a <number> (with or without a decimal point)
   immediately followed by a unit identifier (e.g., px, em, etc.).
   **After a zero length, the unit identifier is optional.**

See also: #251