### PR TITLE
Change GitHub metrics tool to complete on roadmap

### DIFF
--- a/config/site/site.json
+++ b/config/site/site.json
@@ -348,7 +348,7 @@
         },
         {
           "name": "Create community metrics tool to surface open source repo data",
-          "status": "In Progress"
+          "status": "Released"
         },
         { "name": "Launch Open Source Playbook/Toolkit", "status": "In Progress" },
         { "name": "Move blog from Medium to Code.gov platform", "status": "null" },

--- a/src/components/roadmap/__snapshots__/roadmap.container.test.js.snap
+++ b/src/components/roadmap/__snapshots__/roadmap.container.test.js.snap
@@ -36,7 +36,7 @@ Object {
     },
     Object {
       "name": "Create community metrics tool to surface open source repo data",
-      "status": "In Progress",
+      "status": "Released",
     },
     Object {
       "name": "Launch Open Source Playbook/Toolkit",


### PR DESCRIPTION
Update roadmap to indicate that the GitHub metrics tool ([`code-gov-github-metrics`](https://github.com/GSA/code-gov-github-metrics)) is completed