### PR TITLE
Bump style guide to v1.0.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       "integrity": "sha512-AMFnTN4eIn+AOd9qEzbd2dB2QUgSi8G90pdt81eHsUz96LIg8uHi2ApYXZ/eY6JF5jEyNCoWTPEVHY45iHw7rA=="
     },
     "@code.gov/site-map-generator": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.7.tgz",
-      "integrity": "sha512-aHnP/G8DKchZAMV8vEsUoW/1x2RV3PZ3liUzVV+mGpAwXOjZuovLw9A9KyXDpeoeRFXYP+N33qOkO/ZIkmF/kQ==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.8.tgz",
+      "integrity": "sha512-WTZp//K6dWksdMMAMMZeXssOR/r2b5EXkiQ2fYoOT/V5ZPgBzxr3GBZIEajAZ18Lo/mZT7aCNbLPquefOxu+FA==",
       "requires": {
         "@code.gov/api-client": "^0.3.3",
         "dotenv": "^8.0.0",
@@ -1540,9 +1540,9 @@
       },
       "dependencies": {
         "dotenv": {
-          "version": "8.0.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.0.0.tgz",
-          "integrity": "sha512-30xVGqjLjiUOArT4+M5q9sYdvuR4riM6yK9wMcas9Vbp6zZa+ocC9dp6QoftuhTPhFAiLK/0C5Ni2nou/Bk8lg=="
+          "version": "8.1.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
+          "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@code.gov/compliance-dashboard-web-component": "^0.2.0",
     "@code.gov/json-schema-validator-web-component": "^0.2.0",
     "@code.gov/json-schema-web-component": "0.4.0",
-    "@code.gov/site-map-generator": "^1.0.7",
+    "@code.gov/site-map-generator": "^1.0.8",
     "@webcomponents/custom-elements": "^1.2.4",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.10.0",


### PR DESCRIPTION
Update the sitemap.
Release notes: https://github.com/GSA/code-gov-site-map-generator/releases/tag/v1.0.8
