### PR TITLE
Update to latest schema validator component v0.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,9 +1465,9 @@
       "integrity": "sha512-3FHVyzIx8Aj6BzRxt7W1sQ9IiLVtpoKum/IGiYXw1V5kZYbapVQ5A2esfhvoMXJrG6LseEb7ycUf8g5KB+Xoaw=="
     },
     "@code.gov/json-schema-validator-web-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-validator-web-component/-/json-schema-validator-web-component-0.2.0.tgz",
-      "integrity": "sha512-M8HaI9Znn77demP2Rd76ureeBI2SpipxVdSCetRnMKJNvWvjp77ZsawyVtfsBBy06UZ8k9Nic+V+AFBiz5XP8g==",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-validator-web-component/-/json-schema-validator-web-component-0.2.2.tgz",
+      "integrity": "sha512-0+PwPEyjyD7Y6bMxNLFg2XH6KqL0EYUyDOjUnnreGIXir5WV6ZQrNduwt6aitKDE/LpVwdv++ICrnmwUcrgzGw==",
       "requires": {
         "jsoneditor": "^5.25.0"
       },
@@ -8967,6 +8967,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
       "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -8977,7 +8978,8 @@
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
         }
       }
     },
@@ -13608,6 +13610,7 @@
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
       "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "dev": true,
       "requires": {
         "minimist": "~0.0.1",
         "wordwrap": "~0.0.2"
@@ -13616,7 +13619,8 @@
         "wordwrap": {
           "version": "0.0.3",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
-          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@code.gov/code-gov-font": "^0.9.0",
     "@code.gov/code-gov-style": "^2.0.1",
     "@code.gov/compliance-dashboard-web-component": "^0.2.0",
-    "@code.gov/json-schema-validator-web-component": "^0.2.0",
+    "@code.gov/json-schema-validator-web-component": "^0.2.2",
     "@code.gov/json-schema-web-component": "0.4.0",
     "@code.gov/site-map-generator": "^1.0.8",
     "@webcomponents/custom-elements": "^1.2.4",


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Bump @code.gov/json-schema-validator-web-component to latest version [0.2.2](https://github.com/GSA/json-schema-validator-web-component/releases/tag/v0.2.2)


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
- dependency patching this component

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
Currently on [staging](https://staging.code.gov/about/compliance/inventory-code/validate-schema)