### PR TITLE
bump @code.gov/json-schema-web-component from 0.4.0 to 0.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1525,9 +1525,9 @@
       }
     },
     "@code.gov/json-schema-web-component": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-web-component/-/json-schema-web-component-0.4.0.tgz",
-      "integrity": "sha512-AMFnTN4eIn+AOd9qEzbd2dB2QUgSi8G90pdt81eHsUz96LIg8uHi2ApYXZ/eY6JF5jEyNCoWTPEVHY45iHw7rA=="
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-web-component/-/json-schema-web-component-0.4.1.tgz",
+      "integrity": "sha512-EbkgDFZ1Dh32ZDW02tNRWMpTDEnyD4J+7+G6w0saLM80rbc8yxks3brHIuDE7OW3hHDQwCyJaXQjfaBtA44KWQ=="
     },
     "@code.gov/site-map-generator": {
       "version": "1.0.8",
@@ -17327,10 +17327,20 @@
                 "debug": "^3.1.0",
                 "get-uri": "^2.0.0",
                 "http-proxy-agent": "^2.1.0",
-                "https-proxy-agent-snyk-fork": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                "https-proxy-agent-snyk-fork": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
                 "pac-resolver": "^3.0.0",
                 "raw-body": "^2.2.0",
                 "socks-proxy-agent": "^4.0.1"
+              },
+              "dependencies": {
+                "https-proxy-agent-snyk-fork": {
+                  "version": "git://github.com/snyk/node-https-proxy-agent.git#5e86ccb682d0c833c8daa25ee6f91c670161cd66",
+                  "from": "git://github.com/snyk/node-https-proxy-agent.git#fix/https-agent-vuln",
+                  "requires": {
+                    "agent-base": "^4.3.0",
+                    "debug": "^3.1.0"
+                  }
+                }
               }
             },
             "pac-resolver": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@code.gov/code-gov-style": "^2.0.2",
     "@code.gov/compliance-dashboard-web-component": "^0.2.0",
     "@code.gov/json-schema-validator-web-component": "^0.2.2",
-    "@code.gov/json-schema-web-component": "0.4.0",
+    "@code.gov/json-schema-web-component": "0.4.1",
     "@code.gov/site-map-generator": "^1.0.8",
     "@webcomponents/custom-elements": "^1.2.4",
     "@webcomponents/webcomponentsjs": "^2.2.10",


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] bump @code.gov/json-schema-web-component from 0.4.0 to [0.4.1](https://github.com/GSA/json-schema-web-component/releases/tag/v0.4.1)
