### PR TITLE
Bump @code.gov/compliance-dashboard-web-component to v0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1460,9 +1460,9 @@
       }
     },
     "@code.gov/compliance-dashboard-web-component": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/compliance-dashboard-web-component/-/compliance-dashboard-web-component-0.2.0.tgz",
-      "integrity": "sha512-3FHVyzIx8Aj6BzRxt7W1sQ9IiLVtpoKum/IGiYXw1V5kZYbapVQ5A2esfhvoMXJrG6LseEb7ycUf8g5KB+Xoaw=="
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@code.gov/compliance-dashboard-web-component/-/compliance-dashboard-web-component-0.2.1.tgz",
+      "integrity": "sha512-XJriQK/UUIoHt271FGsx9KvOgs7GkT/YzqUtQlHCJNVUyAUrt/iMBZJFWNLsVs19h+X/flXeBKdCWzd2KCpABQ=="
     },
     "@code.gov/json-schema-validator-web-component": {
       "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "@code.gov/cautious": "0.3.0",
     "@code.gov/code-gov-font": "^0.10.0",
     "@code.gov/code-gov-style": "^2.0.2",
-    "@code.gov/compliance-dashboard-web-component": "^0.2.0",
+    "@code.gov/compliance-dashboard-web-component": "^0.2.1",
     "@code.gov/json-schema-validator-web-component": "^0.2.2",
     "@code.gov/json-schema-web-component": "0.4.1",
     "@code.gov/site-map-generator": "^1.0.8",


### PR DESCRIPTION
Release notes for @code.gov/compliance-dashboard-web-component [v0.2.1]. This only includes dependency patching.