### PR TITLE
Update developers link

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -178,6 +178,13 @@ ignore:
     - webpack > watchpack > chokidar > readdirp > micromatch > extglob > expand-brackets > snapdragon > base > cache-base > union-value > set-value:
         reason: None given
         expires: '2019-07-31T13:47:46.480Z'
+  SNYK-JS-AXIOS-472067:
+    - '@code.gov/api-client > axios':
+        reason: no patch available
+        expires: '2019-11-08T17:56:49.923Z'
+    - '@code.gov/site-map-generator > @code.gov/api-client > axios':
+        reason: no patch available
+        expires: '2019-11-08T17:56:49.923Z'
 # patches apply the minimum changes required to fix a vulnerability
 patch:
   SNYK-JS-AXIOS-174505:

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ If you want to override that, specify an `CODE_GOV_API_KEY` environmental variab
 CODE_GOV_API_KEY=l87sfdi7ybc2bic7bai8cb2i176c3b872tb3 npm run start
 ```
 
-You can sign up for an API key at [developers.code.gov](https://developers.code.gov/key.html).
+You can sign up for an [API key](https://open.gsa.gov/api/codedotgov/).
 
 ### File Structure
 

--- a/config/site/site.json
+++ b/config/site/site.json
@@ -40,7 +40,7 @@
         {
           "name": "DEVELOPERS",
           "links": [
-            { "name": "code.gov API", "url": "https://developers.code.gov/basics.html" },
+            { "name": "code.gov API", "url": "https://open.gsa.gov/api/codedotgov/" },
             { "name": "Open Tasks", "url": "/open-tasks?page=1&size=10" },
             {
               "name": "Notebooks",
@@ -85,7 +85,7 @@
         {
           "name": "Developers",
           "links": [
-            { "name": "code.gov API", "url": "https://developers.code.gov/basics.html" },
+            { "name": "code.gov API", "url": "https://open.gsa.gov/api/codedotgov/" },
             { "name": "Open Tasks", "url": "/open-tasks?page=1&size=10" },
             {
               "name": "Notebooks",

--- a/src/components/menu/__snapshots__/menu.container.test.js.snap
+++ b/src/components/menu/__snapshots__/menu.container.test.js.snap
@@ -52,7 +52,7 @@ Object {
       "links": Array [
         Object {
           "name": "code.gov API",
-          "url": "https://developers.code.gov/basics.html",
+          "url": "https://open.gsa.gov/api/codedotgov/",
         },
         Object {
           "name": "Open Tasks",

--- a/src/components/mobile-menu/__snapshots__/mobile-menu.container.test.js.snap
+++ b/src/components/mobile-menu/__snapshots__/mobile-menu.container.test.js.snap
@@ -49,7 +49,7 @@ Object {
       "links": Array [
         Object {
           "name": "code.gov API",
-          "url": "https://developers.code.gov/basics.html",
+          "url": "https://open.gsa.gov/api/codedotgov/",
         },
         Object {
           "name": "Open Tasks",

--- a/src/utils/other.js
+++ b/src/utils/other.js
@@ -63,7 +63,7 @@ export function getConfigValue(path) {
     if (!value) {
       console.warn(`We weren't able to find the value for ${path} in your code-gov-config.json file.
       You can consult examples under the folder found at config/site/examples
-      or consult our developer documentation here: https://developers.code.gov/configure.html`)
+      or consult our developer documentation here: https://open.gsa.gov/api/codedotgov/`)
     }
     return value
   }


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] In the main nav and mobile nav, update the `code.gov API` documentation link to https://open.gsa.gov/api/codedotgov/
* [ ] Update reference to developers.code.gov in the README.md and console warning to point to https://open.gsa.gov/api/codedotgov/
* [ ] Update snyk policy

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

We've moved the code.gov API documentation over to the GSA hosted platform.
Developers.code.gov will be retired temporarily until we can give it an update.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
Currently on [staging](https://staging.code.gov/)