### PR TITLE
update good metadata examples link

### DIFF
--- a/src/components/about-page/html/compliance/how-to-inventory-b.html
+++ b/src/components/about-page/html/compliance/how-to-inventory-b.html
@@ -1,7 +1,7 @@
 <h2 id="examplecodejsonfile">Example code.json file</h2>
 <p>
   We've created some
-  <a href="https://github.com/GSA/code-gov/blob/master/METADATA_EXAMPLES.md"
+  <a href="https://github.com/GSA/code-gov/blob/master/docs/metadata_examples.md"
     >good metadata examples</a
   >
 </p>


### PR DESCRIPTION
**Summary**

Fixes "good metadata examples" broken link to file on github/code-gov repo.

Closes issue #317.

