### PR TITLE
Reject and Break the error block

### DIFF
--- a/src/utils/url-parsing.js
+++ b/src/utils/url-parsing.js
@@ -13,7 +13,9 @@ export function getURLSearchParamsAsSimpleObj(search) {
             result[key] = decodeURIComponent(value)
           }
         } catch (error) {
-          console.error(error)
+          console.error(error);
+          reject(error);
+          break
         }
         return result
       }, {})


### PR DESCRIPTION
In the following execution context. The promise is rejected when an error occurs. Following the same methodology in error handling have advantages.