### PR TITLE
Add github action for stale issues

### DIFF
--- a/.github/workflows/close-stale-issues.yml
+++ b/.github/workflows/close-stale-issues.yml
@@ -1,0 +1,24 @@
+# See https://github.com/actions/stale for more configuration options
+name: "Close stale issues"
+on:
+  schedule:
+  - cron: "0 0 * * *"
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/stale@v1
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'Hello! 👋 It looks like this issue is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it's no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days. Code on!'
+        stale-pr-message: 'Hello! 👋 It looks like this pull request is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it's no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days. Code on!'
+        days-before-stale: 60
+        days-before-close: 7
+        stale-issue-label: '[status] stale'
+        exempt-issue-label: '[status] in progress'
+        stale-pr-label: '[status] stale'
+        exempt-pr-label: '[status] in progress'
+        operations-per-run:
+    description: 'The maximum number of operations per run, used to control rate limiting'
+    default: 30


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Add a GitHub action to update stale issues
This is located in the .github/workflows/close-stale-issues.yml file.

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
Help keep repo clean of old items.
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

Uses the https://github.com/actions/stale action from GitHub. 

Settings:
```
        stale-issue-message: 'Hello! 👋 It looks like this issue is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it's no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days. Code on!'
        stale-pr-message: 'Hello! 👋 It looks like this pull request is stale because it has been open 60 days with no activity. This is usually because the request was already solved or it's no longer applicable. If this issue should remain open, remove the stale label or add a comment. Otherwise, this will be closed in 7 days. Code on!'
        days-before-stale: 60
        days-before-close: 7
        stale-issue-label: '[status] stale'
        exempt-issue-label: '[status] in progress'
        stale-pr-label: '[status] stale'
        exempt-pr-label: '[status] in progress'
        operations-per-run:
    description: 'The maximum number of operations per run, used to control rate limiting'
    default: 30
```
