### PR TITLE
add organization to browse projects card

### DIFF
--- a/src/components/repo-card/repo-card.component.js
+++ b/src/components/repo-card/repo-card.component.js
@@ -30,6 +30,20 @@ export default class RepoCardComponent extends Component {
     }
   }
 
+  get repoOrg() {
+    const agencyOrg = get(this.props.repo, 'organization')
+    if (agencyOrg) {
+      return (
+        <Fragment>
+          <dt>Organization:</dt>
+          <dd>
+            {agencyOrg}
+          </dd>
+        </Fragment>
+      )
+    }
+  }
+
   get repoLanguages() {
     const repo = this.props.repo
     if (some(repo.languages)) {
@@ -72,6 +86,7 @@ export default class RepoCardComponent extends Component {
           <dd>
             <CustomLink to={`/browse-projects?agencies=${agencyAcronym}`}>{agencyName}</CustomLink>
           </dd>
+          {this.repoOrg}
           <CardPart title="Last Updated" text={dateLastModified} />
         </dl>
 


### PR DESCRIPTION

**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features**

* [ ] Add the project Organization to the repo card on the Browse Projects page
* [ ] If there is no Organization (this field is optional in the schema), then this field is not shown


<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?
Customer request #285 
<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**_BEFORE_**
<img width="868" alt="Screen Shot 2019-11-19 at 10 34 56 AM" src="https://user-images.githubusercontent.com/2197515/69161719-96981c00-0ab9-11ea-8287-4681b957038e.png">

**_AFTER_**
<img width="880" alt="Screen Shot 2019-11-19 at 10 34 38 AM" src="https://user-images.githubusercontent.com/2197515/69161801-b16a9080-0ab9-11ea-9f3c-8044fd64536a.png">

**_EXAMPLE PROJECT WITH NO ORG_**
<img width="903" alt="Screen Shot 2019-11-19 at 10 34 47 AM" src="https://user-images.githubusercontent.com/2197515/69161851-c1827000-0ab9-11ea-9b6e-e1e0e660c75d.png">
