### PR TITLE
Bump sitemap version v1.0.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1530,9 +1530,9 @@
       "integrity": "sha512-EbkgDFZ1Dh32ZDW02tNRWMpTDEnyD4J+7+G6w0saLM80rbc8yxks3brHIuDE7OW3hHDQwCyJaXQjfaBtA44KWQ=="
     },
     "@code.gov/site-map-generator": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.9.tgz",
-      "integrity": "sha512-Q8uCNClV1xhsXqXVOnwzMrQYvo76Gog8GRccXI0zm89piHLlHRm8QG7oUg/QkdIwbOoYwudtKwo3QUto8wyGJg==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.10.tgz",
+      "integrity": "sha512-ALC9QCv9FzzR2RBU4ZTyOJA7z4HTE83k9jZCCgKDRQvZL0Nt01D81fkSLtU65WF2F/H/VqykRIBoQKM2acthqQ==",
       "requires": {
         "@code.gov/api-client": "^0.3.3",
         "dotenv": "^8.0.0",
@@ -1540,9 +1540,9 @@
       },
       "dependencies": {
         "dotenv": {
-          "version": "8.1.0",
-          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.1.0.tgz",
-          "integrity": "sha512-GUE3gqcDCaMltj2++g6bRQ5rBJWtkWTmqmD0fo1RnnMuUqHNCt2oTPeDnS9n6fKYvlhn7AeBkb38lymBtWBQdA=="
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@code.gov/compliance-dashboard-web-component": "^0.2.1",
     "@code.gov/json-schema-validator-web-component": "^0.2.2",
     "@code.gov/json-schema-web-component": "0.4.1",
-    "@code.gov/site-map-generator": "^1.0.9",
+    "@code.gov/site-map-generator": "^1.0.10",
     "@webcomponents/custom-elements": "^1.2.4",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.10.0",


### PR DESCRIPTION
[v1.0.10 Release Notes](https://github.com/GSA/code-gov-site-map-generator/releases/tag/v1.0.10)