### PR TITLE
Version bump json-schema-validator-web-component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1465,63 +1465,11 @@
       "integrity": "sha512-XJriQK/UUIoHt271FGsx9KvOgs7GkT/YzqUtQlHCJNVUyAUrt/iMBZJFWNLsVs19h+X/flXeBKdCWzd2KCpABQ=="
     },
     "@code.gov/json-schema-validator-web-component": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-validator-web-component/-/json-schema-validator-web-component-0.2.2.tgz",
-      "integrity": "sha512-0+PwPEyjyD7Y6bMxNLFg2XH6KqL0EYUyDOjUnnreGIXir5WV6ZQrNduwt6aitKDE/LpVwdv++ICrnmwUcrgzGw==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@code.gov/json-schema-validator-web-component/-/json-schema-validator-web-component-0.2.3.tgz",
+      "integrity": "sha512-vZzcsoARtK9cW5rd/WKuFINpwwCSIHRbcqabU+45jragGBSoQhTu5jtdG2ggkzb+VIkXeKSKsOCzp8RpXaa+lQ==",
       "requires": {
-        "jsoneditor": "^5.25.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "5.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-          "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-          "requires": {
-            "co": "^4.6.0",
-            "fast-deep-equal": "^1.0.0",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.3.0"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "1.1.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-          "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-        },
-        "jsoneditor": {
-          "version": "5.34.0",
-          "resolved": "https://registry.npmjs.org/jsoneditor/-/jsoneditor-5.34.0.tgz",
-          "integrity": "sha512-/F7L6oXuRkv2/FKFIL4NMWF0P+oVvSWLJPVEVP/7KGehBj6dtOp5FKdfLcNkIgbqzklXx/NDzHSXYlf64wqmuQ==",
-          "requires": {
-            "ajv": "5.5.2",
-            "brace": "0.11.1",
-            "javascript-natural-sort": "0.7.1",
-            "jmespath": "0.15.0",
-            "json-source-map": "0.4.0",
-            "mobius1-selectr": "2.4.10",
-            "picomodal": "3.0.0",
-            "vanilla-picker": "2.8.0"
-          }
-        },
-        "mobius1-selectr": {
-          "version": "2.4.10",
-          "resolved": "https://registry.npmjs.org/mobius1-selectr/-/mobius1-selectr-2.4.10.tgz",
-          "integrity": "sha512-U/pQ8jZwO7z3Mf9OYzJR6AKfleF5jSBIueKKxGMr/tgyLuTWgchgFyeaXpAIz3Cbp+7eIN1hw5D2gxc4cNnOkQ=="
-        },
-        "vanilla-picker": {
-          "version": "2.8.0",
-          "resolved": "https://registry.npmjs.org/vanilla-picker/-/vanilla-picker-2.8.0.tgz",
-          "integrity": "sha512-NPBxrtLi2LA2mEyRLW+Lyt7Eqtm0t0SmKqscE5RaugXLtJXXjPzy6r65fqLiQkhRc2WoLnmj2m/EnTWKN4hL+g==",
-          "requires": {
-            "@sphinxxxx/color-conversion": "^2.2.1",
-            "drag-tracker": "^1.0.0"
-          }
-        }
+        "jsoneditor": "^6.0.0"
       }
     },
     "@code.gov/json-schema-web-component": {
@@ -9729,9 +9677,9 @@
       "integrity": "sha512-d4sze1JNC454Wdo2fkuyzCr6aHcbL6PGGuFAz0Li/NcOm1tCHGnWDRmJP85dh9IhQErTc2svWFEX5xHIOo//kQ=="
     },
     "handlebars": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.0.tgz",
-      "integrity": "sha512-xkRtOt3/3DzTKMOt3xahj2M/EqNhY988T+imYSlMgs5fVhLN2fmKVVj0LtEGmb+3UUYV5Qmm1052Mm3dIQxOvw==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@code.gov/code-gov-font": "^0.10.0",
     "@code.gov/code-gov-style": "^2.0.3",
     "@code.gov/compliance-dashboard-web-component": "^0.2.1",
-    "@code.gov/json-schema-validator-web-component": "^0.2.2",
+    "@code.gov/json-schema-validator-web-component": "^0.2.3",
     "@code.gov/json-schema-web-component": "0.4.1",
     "@code.gov/site-map-generator": "^1.0.10",
     "@webcomponents/custom-elements": "^1.2.4",


### PR DESCRIPTION
Bumping json-schema-validator-web-component from v0.2.2 to v0.2.3.

https://github.com/GSA/json-schema-validator-web-component/releases/tag/v0.2.3

Bumped handlebars to 4.5.3.