### PR TITLE
Version bump sitemap v1.0.10 to 1.0.11

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1478,9 +1478,9 @@
       "integrity": "sha512-EbkgDFZ1Dh32ZDW02tNRWMpTDEnyD4J+7+G6w0saLM80rbc8yxks3brHIuDE7OW3hHDQwCyJaXQjfaBtA44KWQ=="
     },
     "@code.gov/site-map-generator": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.10.tgz",
-      "integrity": "sha512-ALC9QCv9FzzR2RBU4ZTyOJA7z4HTE83k9jZCCgKDRQvZL0Nt01D81fkSLtU65WF2F/H/VqykRIBoQKM2acthqQ==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@code.gov/site-map-generator/-/site-map-generator-1.0.11.tgz",
+      "integrity": "sha512-xGttLripvlg9Rd6LcECmFJhNBK72YLfaE8zkpj0n+DrNjOHvzZoAfC1ElANLXSe4eilaWs7Z5YNLcJZi3TDmsw==",
       "requires": {
         "@code.gov/api-client": "^0.3.3",
         "dotenv": "^8.0.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@code.gov/compliance-dashboard-web-component": "^0.2.1",
     "@code.gov/json-schema-validator-web-component": "^0.2.3",
     "@code.gov/json-schema-web-component": "0.4.1",
-    "@code.gov/site-map-generator": "^1.0.10",
+    "@code.gov/site-map-generator": "^1.0.11",
     "@webcomponents/custom-elements": "^1.2.4",
     "@webcomponents/webcomponentsjs": "^2.2.10",
     "ajv": "^6.10.0",


### PR DESCRIPTION
https://github.com/GSA/code-gov-site-map-generator/releases/tag/v1.0.11