### PR TITLE
Add node version info

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ Here’s how you can help contribute to code.gov:
 
 ## Getting Started
 
+You will need node to run this website. It's built against v10.15.1. The best way to get node is to install it via `nvm`. See the [nvm installation instructions](https://github.com/nvm-sh/nvm/blob/master/README.md#installation-and-update) to set it up on your system.
+
 After you have cloned this repo, you can use `npm install` to install all of the
 project’s dependencies.
 


### PR DESCRIPTION
Edit the readme.md to add info on the node version that is required to run the front end locally.


`You will need node to run this website. It's built against v10.15.1. The best way to get node is to install it via `nvm`. See the [nvm installation instructions](https://github.com/nvm-sh/nvm/blob/master/README.md#installation-and-update) to set it up on your system.
`