### PR TITLE
Added in 'utils/other' to browse-projects.containe to sort by "code quality"

### DIFF
--- a/src/components/search-page/search-page.container.js
+++ b/src/components/search-page/search-page.container.js
@@ -9,7 +9,6 @@ import {
 import saveFilterOptions from 'actions/save-filter-options'
 import updateSearchFilters from 'actions/update-search-filters'
 import updateSearchParams from 'actions/update-search-params'
-import get from 'lodash.get'
 import { includes, len, overlaps, some } from '@code.gov/cautious'
 import { sortByBestMatch, sortByDataQuality, sortByDate, sortByName } from 'utils/repo-sorting'
 import SearchPageComponent from './search-page.component'


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

This PR fixes/implements the following **bugs/features:**

* [ ] #192 - [Incorrect Repo Sorting Order by Data Quality Score](https://github.com/GSA/code-gov-front-end/issues/192)

<!-- You can skip this if you're fixing a typo or adding an app to the Showcase. -->

Explain the **motivation** for making this change. What existing problem does the pull request solve?

When filtering on the `Browse Projects` page, users want to be able to sort by `Code Quality`.

While digging into this issue, it appeared that the sorting by `Data Quality` issue only occurs when on the `browse-projects` (`browse-projects.container.js`) results page, but not on the `search` (`search-page.container.js`) results page.

<!-- Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. -->

**Test plan (required)**
- Run project locally to ensure that sorting by `Data Quality` works as expected.
- Run `npm run test` to run Unit Tests with a valid `snyk` account

<!-- Make sure tests pass on Circle CI. -->


**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #192 

Open to any and all suggestions to reduce code duplication. I would even think that a longer-term and more maintainable fix would be to combine the `search` and the `browse` functionality into a singular component.