### PR TITLE
the Visit Repo button should not display if the repoURL is null

### DIFF
--- a/src/components/project-page/project-page.component.js
+++ b/src/components/project-page/project-page.component.js
@@ -145,7 +145,8 @@ export default class ProjectPage extends Component {
 
   get repositoryURL() {
     const url = parseRepositoryURL(this.props.repo)
-    if (url) {
+
+    if (url && url !== 'null') {
       return (
         <a href={url} target="_blank" rel="noopener noreferrer">
           <button className="button">Visit Repo</button>

--- a/src/components/project-page/project-page.component.test.js
+++ b/src/components/project-page/project-page.component.test.js
@@ -10,10 +10,10 @@ const props = {
   repo,
   match: {
     params: {
-      repoID: 'repo-id',
-    },
+      repoID: 'repo-id'
+    }
   },
-  updateProject: jest.fn(),
+  updateProject: jest.fn()
 }
 
 let wrapper
@@ -115,6 +115,11 @@ describe('components - ProjectPage', () => {
 
     it('should render nothing if `email` is not provided', () => {
       wrapper.setProps({ repo: { ...repo, repositoryURL: undefined } })
+      testRenderEmpty(instance.repositoryURL)
+    })
+
+    it('should render nothing if `repositoryURL` is a null string', () => {
+      wrapper.setProps({ repo: { ...repo, repositoryURL: 'null' } })
       testRenderEmpty(instance.repositoryURL)
     })
   })


### PR DESCRIPTION
https://github.com/GSA/code-gov-front-end/issues/164