### PR TITLE
Add local env files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,9 @@ typings/
 .DS_Store
 # Cypress files
 cypress.env.json
+
+# env files
+.env.local
+.env.development.local
+.env.test.local
+.env.production.local


### PR DESCRIPTION
**Summary**

Support the usage of local `.env` files in order to avoid accidentally committing API key.