### PR TITLE
Use dotenv-flow to override .env during development

### DIFF
--- a/config/webpack/webpack.shared.js
+++ b/config/webpack/webpack.shared.js
@@ -11,7 +11,7 @@ const ImageminPlugin = require('imagemin-webpack-plugin').default
 const rootDir = dirname(dirname(__dirname))
 const nodeModulesDir = join(rootDir, 'node_modules')
 
-require('dotenv').config()
+require('dotenv-flow').config()
 
 // https://webpack.js.org/guides/public-path/
 let PUBLIC_PATH = process.env.BASEURL || process.env.PUBLIC_PATH || '/'
@@ -47,7 +47,6 @@ const entry = {
 }
 
 const siteConfigPath = process.env.CODE_GOV_CONFIG_JSON || join(rootDir, '/config/site/site.json')
-console.log('process.env.CODE_GOV_CONFIG_JSON:', process.env.CODE_GOV_CONFIG_JSON)
 
 /* eslint-disable import/no-dynamic-require */
 const SITE_CONFIG = require(siteConfigPath)

--- a/package-lock.json
+++ b/package-lock.json
@@ -3909,6 +3909,15 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
       "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow=="
     },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
     "bl": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
@@ -6305,6 +6314,21 @@
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-6.2.0.tgz",
       "integrity": "sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w=="
+    },
+    "dotenv-flow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-3.1.0.tgz",
+      "integrity": "sha512-BMA8vfu2DbAx5x5G3C+tgb1hCbONggZTSpBE7B4yCPG5vziKX/lA3CzsjdGKlPvLxZgTbP1qb+KlWux8pYqsmA==",
+      "requires": {
+        "dotenv": "^8.0.0"
+      },
+      "dependencies": {
+        "dotenv": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.2.0.tgz",
+          "integrity": "sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw=="
+        }
+      }
     },
     "dotnet-deps-parser": {
       "version": "4.9.0",
@@ -10326,6 +10350,7 @@
           "dev": true,
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -19110,6 +19135,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },
@@ -20050,6 +20076,7 @@
           "integrity": "sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==",
           "optional": true,
           "requires": {
+            "bindings": "^1.5.0",
             "nan": "^2.12.1",
             "node-pre-gyp": "*"
           },

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "custom-event-polyfill": "^1.0.7",
     "devicons": "^1.8.0",
     "dotenv": "^6.2.0",
+    "dotenv-flow": "^3.1.0",
     "event-hooks-webpack-plugin": "^2.1.1",
     "favicons": "^5.4.1",
     "file-loader": "^2.0.0",


### PR DESCRIPTION
This enables the use of `.env.local` to define API keys. Any key not defined in `.env.local` will fall back to the value in `.env`.