### PR TITLE
Code-gov-font npm bump

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -989,9 +989,9 @@
       "integrity": "sha512-9c6fAJ9Zr1wkFM/8k1USq9HkxtoybqO9KKmdAI/a+PzjLofRBIdjYweOF5VOeQsfUdiVeF46uHXwFU3Je7MnDQ=="
     },
     "@code.gov/code-gov-font": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-font/-/code-gov-font-0.10.0.tgz",
-      "integrity": "sha512-gHDmijuxEUiHEF+Y0dYaaFRgFBCZmAGDagp945aeBAnxPrTQnwFtXRKdiDba69TwDhTvIGgG2s+zOd3+vnF8wQ=="
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/@code.gov/code-gov-font/-/code-gov-font-0.10.1.tgz",
+      "integrity": "sha512-72QMCYI58OxTDNL8fhaL2V2OUQuUhW9wEK1CtN5kTF9bbwYWs80m/aiqchtWTZItMFeh5wZp/4hF7HASghGq0w=="
     },
     "@code.gov/code-gov-style": {
       "version": "2.0.4",
@@ -1006,6 +1006,11 @@
         "prismjs": "^1.15.0"
       },
       "dependencies": {
+        "@code.gov/code-gov-font": {
+          "version": "0.10.0",
+          "resolved": "https://registry.npmjs.org/@code.gov/code-gov-font/-/code-gov-font-0.10.0.tgz",
+          "integrity": "sha512-gHDmijuxEUiHEF+Y0dYaaFRgFBCZmAGDagp945aeBAnxPrTQnwFtXRKdiDba69TwDhTvIGgG2s+zOd3+vnF8wQ=="
+        },
         "debug": {
           "version": "3.2.6",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
     "@babel/preset-react": "^7.0.0",
     "@code.gov/api-client": "^0.3.6",
     "@code.gov/cautious": "0.3.0",
-    "@code.gov/code-gov-font": "^0.10.0",
+    "@code.gov/code-gov-font": "^0.10.1",
     "@code.gov/code-gov-style": "^2.0.4",
     "@code.gov/json-schema-validator-web-component": "^0.2.3",
     "@code.gov/site-map-generator": "^1.0.11",


### PR DESCRIPTION
Bumped code-gov-font package to v0.10.1. Incorporates fontello-cli bump from 0.4.0 to 0.5.0. 