### PR TITLE
Enable Federalist previews

### DIFF
--- a/config/webpack/webpack.shared.js
+++ b/config/webpack/webpack.shared.js
@@ -243,7 +243,7 @@ module.exports = {
         appleStartup: false
       },
       inject: true,
-      prefix: '/assets/img/favicons',
+      prefix: join(PUBLIC_PATH, '/assets/img/favicons'),
       output: './assets/img/favicons/',
       config: {
         favicons: true,

--- a/src/browser-history.js
+++ b/src/browser-history.js
@@ -1,5 +1,5 @@
 import { createBrowserHistory } from 'history'
 
-const history = createBrowserHistory()
+const history = createBrowserHistory({ basename: PUBLIC_PATH })
 
 export default history

--- a/src/components/about-page/index.js
+++ b/src/components/about-page/index.js
@@ -19,7 +19,7 @@ import Resources from './resources.component'
 import MeasuringCode from './measuring-code.component'
 import Licensing from './licensing.component'
 
-const abouturl = `${PUBLIC_PATH}about`
+const abouturl = `/about`
 
 const links = [
   {

--- a/src/components/app/__snapshots__/app.component.test.js.snap
+++ b/src/components/app/__snapshots__/app.component.test.js.snap
@@ -30,25 +30,7 @@ exports[`components - App render should render correctly 1`] = `
       isDark={true}
     />
     <withRouter(Connect(Menu)) />
-    <Switch
-      location={
-        Location {
-          "assign": [Function],
-          "hash": "",
-          "host": "test.com",
-          "hostname": "test.com",
-          "href": "http://test.com/",
-          "origin": "http://test.com",
-          "pathname": "/",
-          "port": "",
-          "protocol": "http:",
-          "reload": [Function],
-          "replace": [Function],
-          "search": "",
-          "toString": [Function],
-        }
-      }
-    >
+    <Switch>
       <Route
         component={[Function]}
         exact={true}
@@ -93,4 +75,4 @@ exports[`components - App render should render correctly 1`] = `
     <Connect(Footer) />
   </div>
 </Connect(ConnectedRouter)>
-`
+`;

--- a/src/components/app/app.component.js
+++ b/src/components/app/app.component.js
@@ -14,7 +14,7 @@ import Menu from 'components/menu'
 import Footer from 'components/footer'
 import OfficialBanner from 'components/official-banner'
 import PrivacyPolicy from 'components/privacy-policy'
-import { refreshView } from 'utils/other'
+import { refreshView, isHomepage } from 'utils/other'
 
 export default class AppComponent extends Component {
   componentDidMount() {
@@ -25,15 +25,12 @@ export default class AppComponent extends Component {
   }
 
   render() {
-    const location = window.location
-    const isHomepage = location.pathname === '/'
-
     return (
       <ConnectedRouter history={history}>
         <div className="App">
           {isHomepage ? <OfficialBanner isDark /> : <OfficialBanner />}
           <Menu />
-          <Switch location={location}>
+          <Switch>
             <Route exact path="/" component={Home} />
             <Route path="/search" component={SearchPage} />
             <Route path="/about" component={AboutPage} />

--- a/src/components/footer/footer.container.js
+++ b/src/components/footer/footer.container.js
@@ -1,16 +1,13 @@
 /* global PUBLIC_PATH */
 import { connect } from 'react-redux'
-import { getConfigValue } from 'utils/other'
+import { getConfigValue, isHomepage } from 'utils/other'
 import Footer from './footer.component'
 
-export const mapStateToProps = ({ router }) => {
-  const onHomePage = router.location.pathname === PUBLIC_PATH
-  return {
+export const mapStateToProps = ({ router }) => ({
     color: 'white',
     links: getConfigValue('content.footer.links'),
     logos: getConfigValue('content.footer.logos'),
     socials: getConfigValue('content.footer.socials')
-  }
-}
+})
 
 export default connect(mapStateToProps)(Footer)

--- a/src/components/menu/__snapshots__/menu.container.test.js.snap
+++ b/src/components/menu/__snapshots__/menu.container.test.js.snap
@@ -95,8 +95,8 @@ Object {
       "name": "SOCIAL",
     },
   ],
-  "onHomePage": false,
+  "onHomePage": true,
   "searchDropdown": "test-search-dropdown",
   "siteTitle": "code.gov",
 }
-`
+`;

--- a/src/components/menu/menu.container.js
+++ b/src/components/menu/menu.container.js
@@ -2,22 +2,19 @@
 
 import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
-import { getConfigValue } from 'utils/other'
+import { getConfigValue, isHomepage } from 'utils/other'
 import toggleSearchDropdown from 'actions/toggle-search-dropdown'
 import MenuComponent from './menu.component'
 
-export const mapStateToProps = ({ router, searchDropdown }) => {
-  const onHomePage = router.location.pathname === PUBLIC_PATH
-  return {
+export const mapStateToProps = ({ router, searchDropdown }) => ({
     color: 'white',
     logoDark: getConfigValue('content.header.logos.dark'),
     logoLight: getConfigValue('content.header.logos.light'),
     menu: getConfigValue('content.header.menu'),
-    onHomePage,
+    onHomePage: isHomepage,
     searchDropdown,
     siteTitle: getConfigValue('title')
-  }
-}
+})
 
 export const mapDispatchToProps = dispatch => ({
   toggleSearchDropdown: () => dispatch(toggleSearchDropdown())

--- a/src/components/mobile-menu-control/__snapshots__/mobile-menu-control.container.test.js.snap
+++ b/src/components/mobile-menu-control/__snapshots__/mobile-menu-control.container.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`containers - MobileMenuControl mapStateToProps should return the correct properties 1`] = `
 Object {
-  "color": "dark",
+  "color": "white",
   "displayMobileMenu": true,
 }
-`
+`;

--- a/src/components/mobile-menu-control/mobile-menu-control.container.js
+++ b/src/components/mobile-menu-control/mobile-menu-control.container.js
@@ -3,11 +3,11 @@ import { connect } from 'react-redux'
 import hideMobileMenu from 'actions/hide-mobile-menu'
 import showMobileMenu from 'actions/show-mobile-menu'
 import toggleMobileMenu from 'actions/toggle-mobile-menu'
+import { refreshView, isHomepage } from 'utils/other'
 import MobileMenuControlComponent from './mobile-menu-control.component'
 
 export const mapStateToProps = ({ displayMobileMenu, router }) => {
-  const onHomePage = router.location.pathname === PUBLIC_PATH
-  const color = onHomePage ? 'white' : 'dark'
+  const color = isHomepage ? 'white' : 'dark'
   return {
     color,
     displayMobileMenu

--- a/src/utils/other.js
+++ b/src/utils/other.js
@@ -263,3 +263,5 @@ export function prettify(text) {
     match => `<br/>${match.replace(/[A-Za-z]{1,25}/, name => `<b>${name}</b>`)}`
   )
 }
+
+export const isHomepage = window.location.pathname === PUBLIC_PATH

--- a/styles/theme/_uswds-theme-general.scss
+++ b/styles/theme/_uswds-theme-general.scss
@@ -25,7 +25,7 @@ Relative image file path
 ----------------------------------------
 */
 
-$theme-image-path: "/uswds/img";
+$theme-image-path: "./uswds/img";
 
 /*
 ----------------------------------------

--- a/styles/theme/_uswds-theme-typography.scss
+++ b/styles/theme/_uswds-theme-typography.scss
@@ -77,7 +77,7 @@ Relative font file path
 ----------------------------------------
 */
 
-$theme-font-path: "/uswds/fonts";
+$theme-font-path: "./uswds/fonts";
 
 /*
 ----------------------------------------


### PR DESCRIPTION
This updates the path of various assets and routing components to accommodate the unique url structure of Federalist preview branches. This will allow changes to be view on the branch specific URLs like https://federalist-88023b0b-4406-431f-932d-5fd82c70c515.app.cloud.gov/preview/gsa/code-gov-front-end/bh-public-path/ without having to merge to `staging` to view. 

This appears to be working well locally and on the Federalist branches, but I would like to see how it works on the staging branch before merging it to production.

There is also one caveat that will either need to be accepted, or worked around in a future PR. There is logic hardcoded in the 404.html and index.html pages that strips the path/query string of the URL out and redirects to the base URL - this is the expected behavior on the production site, but on a Federalist preview URL it will cause an infinite reloading loop.