### PR TITLE
Fix repo explorer sorting logic

### DIFF
--- a/src/components/browse-projects/__snapshots__/browse-projects.component.test.js.snap
+++ b/src/components/browse-projects/__snapshots__/browse-projects.component.test.js.snap
@@ -100,10 +100,10 @@ exports[`components - BrowseProjects render should render correctly 1`] = `
                   "calls": Array [
                     Array [
                       Object {
-                        "repoId": "repo-2",
+                        "repoId": "repo-1",
                       },
                       Object {
-                        "repoId": "repo-1",
+                        "repoId": "repo-2",
                       },
                     ],
                   ],

--- a/src/components/browse-projects/__snapshots__/browse-projects.component.test.js.snap
+++ b/src/components/browse-projects/__snapshots__/browse-projects.component.test.js.snap
@@ -93,8 +93,33 @@ exports[`components - BrowseProjects render should render correctly 1`] = `
           onSortChange={[MockFunction]}
           options={
             Array [
-              "sort-1",
-              "sort-2",
+              Object {
+                "label": "sort-1",
+                "selected": true,
+                "sortFn": [MockFunction] {
+                  "calls": Array [
+                    Array [
+                      Object {
+                        "repoId": "repo-2",
+                      },
+                      Object {
+                        "repoId": "repo-1",
+                      },
+                    ],
+                  ],
+                  "results": Array [
+                    Object {
+                      "type": "return",
+                      "value": undefined,
+                    },
+                  ],
+                },
+              },
+              Object {
+                "label": "sort-2",
+                "selected": false,
+                "sortFn": [MockFunction],
+              },
             ]
           }
         />

--- a/src/components/browse-projects/__snapshots__/browse-projects.container.test.js.snap
+++ b/src/components/browse-projects/__snapshots__/browse-projects.container.test.js.snap
@@ -74,19 +74,22 @@ Object {
     Object {
       "label": "Data Quality",
       "selected": false,
+      "sortFn": [Function],
       "value": "data_quality",
     },
     Object {
       "label": "A-Z",
       "selected": false,
+      "sortFn": [Function],
       "value": "a-z",
     },
     Object {
       "label": "Last Updated",
       "selected": false,
+      "sortFn": [Function],
       "value": "last_updated",
     },
   ],
   "total": 2,
 }
-`
+`;

--- a/src/components/browse-projects/browse-projects.component.js
+++ b/src/components/browse-projects/browse-projects.component.js
@@ -44,6 +44,8 @@ export default class BrowseProjects extends React.Component {
   get reposContainer() {
     if (some(this.props.repos)) {
       try {
+        const { sortFn } = this.props.sortOptions.find(option => option.selected)
+        const sortedRepos = [...this.props.repos].sort(sortFn)
         return (
           <div>
             <FilterTags filters={this.props.filterTags} onClick={::this.props.onFilterTagClick} />
@@ -51,7 +53,7 @@ export default class BrowseProjects extends React.Component {
               <QualityPopover />
             </div>
             <ul className="usa-card-group padding-top-3">
-              {this.props.repos.map(repo => (
+              {sortedRepos.map(repo => (
                 <RepoCard key={repo.repoID} repo={repo} />
               ))}
             </ul>

--- a/src/components/browse-projects/browse-projects.component.test.js
+++ b/src/components/browse-projects/browse-projects.component.test.js
@@ -12,7 +12,18 @@ const props = {
   total: 2,
   repos: [{ repoId: 'repo-1' }, { repoId: 'repo-2' }],
   boxes: ['box-1', 'box-2'],
-  sortOptions: ['sort-1', 'sort-2'],
+  sortOptions: [
+    {
+      label: 'sort-1',
+      sortFn: jest.fn(),
+      selected: true
+    },
+    {
+      label: 'sort-2',
+      sortFn: jest.fn(),
+      selected: false
+    }
+  ],
   onSortChange: jest.fn(),
   filterTags: ['filter-1', 'filter-2'],
   onFilterTagClick: jest.fn(),

--- a/src/components/browse-projects/browse-projects.container.js
+++ b/src/components/browse-projects/browse-projects.container.js
@@ -6,6 +6,7 @@ import saveFilterOptions from 'actions/save-filter-options'
 import updateBrowseFilters from 'actions/update-browse-filters'
 import updateBrowseParams from 'actions/update-browse-params'
 import BrowseProjectsComponent from './browse-projects.component'
+import { sortByName, sortByDataQuality, sortByDate } from '../../utils/repo-sorting'
 
 export const mapStateToProps = ({ browseParams, browseResults, filters }) => {
   const categories = ['agencies', 'languages', 'licenses', 'usageTypes']
@@ -39,17 +40,20 @@ export const mapStateToProps = ({ browseParams, browseResults, filters }) => {
     {
       label: 'Data Quality',
       value: 'data_quality',
-      selected: selectedSorting === 'data_quality'
+      selected: selectedSorting === 'data_quality',
+      sortFn: sortByDataQuality
     },
     {
       label: 'A-Z',
       value: 'a-z',
-      selected: selectedSorting === 'a-z'
+      selected: selectedSorting === 'a-z',
+      sortFn: sortByName
     },
     {
       label: 'Last Updated',
       value: 'last_updated',
-      selected: selectedSorting === 'last_updated'
+      selected: selectedSorting === 'last_updated',
+      sortFn: sortByDate
     }
   ]
 
@@ -88,7 +92,4 @@ export const mapDispatchToProps = dispatch => ({
   }
 })
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(BrowseProjectsComponent)
+export default connect(mapStateToProps, mapDispatchToProps)(BrowseProjectsComponent)


### PR DESCRIPTION
**Summary**

<!-- Summary of the PR -->

Addresses a flaw in the sorting logic for browsing repos / puts that logic closer to the actual rendering

**Motivation**

- Leverages existing sort fns to correctly sort derived repos from the state on dropdown change

**Test plan (required)**

- Test all three dropdown options for correct outcomes with a variety of filters
- Added additional Cypress tests

<!-- Make sure tests pass on Circle CI. -->

**Code formatting**

- All commits run through pretty-quick script

**Closing issues**

<!-- Put `closes #XXXX` in your comment to auto-close the issue that your PR fixes (if such). -->
Fixes #192 

**TODO / WIP Questions**
- Appears to be a single snapshot test [failing on master branch](https://github.com/GSA/code-gov-front-end/blob/7a30769779a3a06ed9decb62724fce86a43b2f8e/src/components/search-page/search-page.container.test.js#L97); if confirmed/reproducible, could fix here or open a separate PR? **Update**: looks like this was because I was incorrectly developing with nodev12 instead of 10 as the `.nvmrc` specifies / can ignore.
- Having trouble refactoring an existing Cypress test (see comment below)
- Am a bit confused without this sorting logic how this feature was even partially working previously?