### PR TITLE
Fix #526 by updating agency orgs list

### DIFF
--- a/config/site/agency_list.json
+++ b/config/site/agency_list.json
@@ -125,7 +125,7 @@
     "complianceDashboard": true,
     "agencyDashboard": true,
     "score": 8,
-    "orgs": ["Federal-Aviation-Administration", "IMDProjects", "usdot-fhwa-stol", "usdot-jpo-ode"]
+    "orgs": ["usedgov"]
   },
   {
     "id": 5,
@@ -332,14 +332,7 @@
     "complianceDashboard": true,
     "agencyDashboard": true,
     "score": 8,
-    "orgs": [
-      "CA-CST-Library",
-      "CA-CST-SII",
-      "historyatstate",
-      "IIP-Design",
-      "state-hiu",
-      "usstatedept"
-    ]
+    "orgs": ["Federal-Aviation-Administration", "IMDProjects", "usdot-fhwa-stol", "usdot-jpo-ode"]
   },
   {
     "id": 14,


### PR DESCRIPTION
**Summary**

Update agency GitHub organization list for U.S Department of Transportation and Department of Education.

This PR fixes the following **bugs**

* [x] Fix GitHub organizations listed under "Department of Education" (currently listing USDOT GitHub organizations).
* [x] Fix GitHub organizations listed under "Department of Transportation" (currently listing Department of State GitHub organizations).

**Test plan (required)**

Only changed the json config file for agency list. Can confirm that the file changed is still valid json.

**Closing issues**

Closes #526 
